### PR TITLE
fixed bug in get_lower_boundary_design

### DIFF
--- a/R/TwoStageDesign.R
+++ b/R/TwoStageDesign.R
@@ -72,9 +72,9 @@ setGeneric("TwoStageDesign", function(n1, ...) standardGeneric("TwoStageDesign")
 #' @export
 setMethod("TwoStageDesign", signature = "numeric",
 function(n1, c1f, c1e, n2_pivots, c2_pivots, order = NULL, ...) {
+    if (length(n2_pivots) != length(c2_pivots))
+        stop("n2_pivots and c2_pivots must be of same length!")
     if (is.null(order)) {
-        if (length(n2_pivots) != length(c2_pivots))
-            stop("n2_pivots and c2_pivots must be of same length!")
         order <- length(n2_pivots)
     } else if (length(n2_pivots) != order) {
         n2_pivots <- rep(n2_pivots[1], order)

--- a/R/boundary_designs.R
+++ b/R/boundary_designs.R
@@ -77,7 +77,7 @@ setMethod("get_lower_boundary_design", signature("TwoStageDesign"),
                   n1,
                   initial_design@c1f - c1_buffer,
                   initial_design@c1e - c1_buffer,
-                  n2_pivots,
+                  rep(n2_pivots, length(initial_design@c2_pivots)),
                   initial_design@c2_pivots - c2_buffer,
                   order = length(initial_design@c2_pivots)
               )

--- a/tests/testthat/test_TwoStageDesign.R
+++ b/tests/testthat/test_TwoStageDesign.R
@@ -120,3 +120,29 @@ test_that("defining order does not destroy pivots", {
     )
 
 }) # end 'defining order does not destroy pivots'
+
+
+
+test_that("boundary designs keep monotonicity", {
+    n2   <- seq(100, 40, length.out = number_knots)
+    c2   <- seq(2.0, 0.0, length.out = number_knots)
+    d    <- TwoStageDesign(n1, c1f, c1e, n2, c2, number_knots)
+    d_lb <- get_lower_boundary_design(d)
+    d_ub <- get_upper_boundary_design(d)
+
+    expect_equal(
+        sign(diff(d_lb@n2_pivots)),
+        sign(diff(d@n2_pivots))
+    )
+
+    expect_equal(
+        sign(diff(d_ub@n2_pivots)),
+        sign(diff(d@n2_pivots))
+    )
+
+    expect_equal(
+        sign(diff(d_ub@c2_pivots)),
+        sign(diff(d@c2_pivots))
+    )
+
+}) # end 'boundary designs keep monotonicity'

--- a/tests/testthat/test_TwoStageDesign.R
+++ b/tests/testthat/test_TwoStageDesign.R
@@ -131,8 +131,8 @@ test_that("boundary designs keep monotonicity", {
     d_ub <- get_upper_boundary_design(d)
 
     expect_equal(
-        sign(diff(d_lb@n2_pivots)),
-        sign(diff(d@n2_pivots))
+        sign(diff(d_lb@c2_pivots)),
+        sign(diff(d@c2_pivots))
     )
 
     expect_equal(


### PR DESCRIPTION
I think we do the best if we force the user to define n2_pivots and c2_pivots of equal length. Do you agree?