### PR TITLE
output of different constraints can be of different length

### DIFF
--- a/R/PointMassPrior.R
+++ b/R/PointMassPrior.R
@@ -33,7 +33,7 @@ setClass("PointMassPrior", representation(
 #' @rdname PointMassPrior-class
 #' @export
 PointMassPrior <- function(theta, mass, label = NA_character_) {
-    if (sum(mass) != 1)
+    if (round(sum(mass), 10) != 1)
         stop("mass must sum to one")
     new("PointMassPrior", theta = theta[order(theta)], mass = mass[order(theta)],
         label = label)

--- a/R/constraints.R
+++ b/R/constraints.R
@@ -204,13 +204,13 @@ subject_to <- function(...) {
 setMethod("evaluate", signature("ConstraintsCollection", "TwoStageDesign"),
           function(s, design, optimization = FALSE, ...) {
               x1_cont <- scaled_integration_pivots(design)
-              unconditional <- as.numeric(sapply(
+              unconditional <- as.numeric(unlist(sapply(
                   s@unconditional_constraints,
                   function(cnstr) evaluate(cnstr, design, optimization, ...)
-              ))
-              conditional <- as.numeric(sapply(
+              )))
+              conditional <- as.numeric(unlist(sapply(
                   s@conditional_constraints,
                   function(cnstr) evaluate(cnstr, design, x1_cont, optimization, ...)
-              ))
+              )))
               return(c(unconditional, conditional))
           })

--- a/tests/testthat/test_PointMassPrior.R
+++ b/tests/testthat/test_PointMassPrior.R
@@ -141,6 +141,10 @@ test_that("multiple points prior", {
         post@mass[2],# good outcome should shift mass to higher pivot
         post@mass[1])
 
+    expect_true(is(posterior(Normal(), PointMassPrior(c(0, .5), c(.5, .5)), -.1, 84),
+                "PointMassPrior")) # rounding issue in computing posterior
+
+
 })
 
 

--- a/tests/testthat/test_constraints.R
+++ b/tests/testthat/test_constraints.R
@@ -123,6 +123,24 @@ test_that("score vs score inequalities", {
 
 
 
+test_that("output of constraints can be of different length", {
+    toer <- Power(Normal(), PointMassPrior(0, 1))
+
+    setClass("C2Difference", contains = "UnconditionalScore")
+    C2Difference <- function() new("C2Difference")
+    setMethod("evaluate",
+              signature("C2Difference", "TwoStageDesign"),
+              function(s, design, optimization = FALSE, ...)
+                  diff(c2(design, scaled_integration_pivots(design)))
+    )
+    c2d <- C2Difference()
+
+    cnstrs <- subject_to(toer <= .025, c2d <= 0)
+
+    expect_equal(length(evaluate(cnstrs, design)), length(design@c2_pivots))
+})
+
+
 test_that("show method", {
 
     cp <- ConditionalPower(Normal(two_armed = FALSE), PointMassPrior(.4, 1))


### PR DESCRIPTION
Currently, the output of all scores in a constraints collection must be of the same length. 
This issue is fixed now and a test is included.